### PR TITLE
Fix `__init__()`

### DIFF
--- a/src/blue_wallet_client/blue_wallet_client.py
+++ b/src/blue_wallet_client/blue_wallet_client.py
@@ -45,7 +45,7 @@ class BlueWalletClient:
             root_url (str): URL to LNDHub backend. Defaults to Blue wallet backend.
         """
 
-        self.self.root_url = root_url
+        self.root_url = root_url
 
         retry_strategy = Retry(
             total=3,


### PR DESCRIPTION
There was bug introduced with #2.

Tested with my work in progress integration of blue_wallet_client into SatSale.